### PR TITLE
Fix build with latest zxing-cpp master sources (release 1.2.0)

### DIFF
--- a/examples/QmlBarcodeReader/qml/ScannerPage.qml
+++ b/examples/QmlBarcodeReader/qml/ScannerPage.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.12
 import QtQuick.Controls 2.12
+import QtQuick.Window 2.12
 import QtMultimedia 5.12
 import com.scythestudio.scodes 1.0
 

--- a/src/SCodes.pri
+++ b/src/SCodes.pri
@@ -23,17 +23,20 @@ HEADERS += \
     $$PWD/zxing-cpp/core/src/BitArray.h \
     $$PWD/zxing-cpp/core/src/BitHacks.h \
     $$PWD/zxing-cpp/core/src/BitMatrix.h \
+    $$PWD/zxing-cpp/core/src/BitMatrixCursor.h \
     $$PWD/zxing-cpp/core/src/BitMatrixIO.h \
     $$PWD/zxing-cpp/core/src/BitSource.h \
     $$PWD/zxing-cpp/core/src/ByteArray.h \
     $$PWD/zxing-cpp/core/src/ByteMatrix.h \
     $$PWD/zxing-cpp/core/src/CharacterSet.h \
     $$PWD/zxing-cpp/core/src/CharacterSetECI.h \
+    $$PWD/zxing-cpp/core/src/ConcentricFinder.h \
     $$PWD/zxing-cpp/core/src/CustomData.h \
     $$PWD/zxing-cpp/core/src/DecodeHints.h \
     $$PWD/zxing-cpp/core/src/DecodeStatus.h \
     $$PWD/zxing-cpp/core/src/DecoderResult.h \
     $$PWD/zxing-cpp/core/src/DetectorResult.h \
+    $$PWD/zxing-cpp/core/src/Flags.h \
     $$PWD/zxing-cpp/core/src/GTIN.h \
     $$PWD/zxing-cpp/core/src/GenericGF.h \
     $$PWD/zxing-cpp/core/src/GenericGFPoly.h \
@@ -54,21 +57,22 @@ HEADERS += \
     $$PWD/zxing-cpp/core/src/Reader.h \
     $$PWD/zxing-cpp/core/src/ReedSolomonDecoder.h \
     $$PWD/zxing-cpp/core/src/ReedSolomonEncoder.h \
+    $$PWD/zxing-cpp/core/src/RegressionLine.h \
     $$PWD/zxing-cpp/core/src/Result.h \
     $$PWD/zxing-cpp/core/src/ResultMetadata.h \
     $$PWD/zxing-cpp/core/src/ResultPoint.h \
+    $$PWD/zxing-cpp/core/src/Scope.h \
+    $$PWD/zxing-cpp/core/src/StructuredAppend.h \
     $$PWD/zxing-cpp/core/src/TextDecoder.h \
     $$PWD/zxing-cpp/core/src/TextEncoder.h \
     $$PWD/zxing-cpp/core/src/TextUtfEncoding.h \
+    $$PWD/zxing-cpp/core/src/ThresholdBinarizer.h \
     $$PWD/zxing-cpp/core/src/TritMatrix.h \
     $$PWD/zxing-cpp/core/src/WhiteRectDetector.h \
     $$PWD/zxing-cpp/core/src/ZXBigInteger.h \
     $$PWD/zxing-cpp/core/src/ZXConfig.h \
     $$PWD/zxing-cpp/core/src/ZXContainerAlgorithms.h \
-    $$PWD/zxing-cpp/core/src/ZXFlags.h \
     $$PWD/zxing-cpp/core/src/ZXNullable.h \
-    $$PWD/zxing-cpp/core/src/ZXNumeric.h \
-    $$PWD/zxing-cpp/core/src/ZXStrConvWorkaround.h \
     $$PWD/zxing-cpp/core/src/ZXTestSupport.h \
     $$PWD/zxing-cpp/core/src/aztec/AZDecoder.h \
     $$PWD/zxing-cpp/core/src/aztec/AZDetector.h \
@@ -79,12 +83,10 @@ HEADERS += \
     $$PWD/zxing-cpp/core/src/aztec/AZReader.h \
     $$PWD/zxing-cpp/core/src/aztec/AZToken.h \
     $$PWD/zxing-cpp/core/src/aztec/AZWriter.h \
-    $$PWD/zxing-cpp/core/src/datamatrix/DMBitMatrixParser.h \
+    $$PWD/zxing-cpp/core/src/datamatrix/DMBitLayout.h \
     $$PWD/zxing-cpp/core/src/datamatrix/DMDataBlock.h \
     $$PWD/zxing-cpp/core/src/datamatrix/DMDecoder.h \
-    $$PWD/zxing-cpp/core/src/datamatrix/DMDefaultPlacement.h \
     $$PWD/zxing-cpp/core/src/datamatrix/DMDetector.h \
-    $$PWD/zxing-cpp/core/src/datamatrix/DMECB.h \
     $$PWD/zxing-cpp/core/src/datamatrix/DMECEncoder.h \
     $$PWD/zxing-cpp/core/src/datamatrix/DMEncoderContext.h \
     $$PWD/zxing-cpp/core/src/datamatrix/DMHighLevelEncoder.h \
@@ -105,35 +107,23 @@ HEADERS += \
     $$PWD/zxing-cpp/core/src/oned/ODCode39Writer.h \
     $$PWD/zxing-cpp/core/src/oned/ODCode93Reader.h \
     $$PWD/zxing-cpp/core/src/oned/ODCode93Writer.h \
-    $$PWD/zxing-cpp/core/src/oned/ODEAN13Reader.h \
+    $$PWD/zxing-cpp/core/src/oned/ODDataBarCommon.h \
+    $$PWD/zxing-cpp/core/src/oned/ODDataBarExpandedReader.h \
+    $$PWD/zxing-cpp/core/src/oned/ODDataBarReader.h \
     $$PWD/zxing-cpp/core/src/oned/ODEAN13Writer.h \
-    $$PWD/zxing-cpp/core/src/oned/ODEAN8Reader.h \
     $$PWD/zxing-cpp/core/src/oned/ODEAN8Writer.h \
-    $$PWD/zxing-cpp/core/src/oned/ODEANManufacturerOrgSupport.h \
     $$PWD/zxing-cpp/core/src/oned/ODITFReader.h \
     $$PWD/zxing-cpp/core/src/oned/ODITFWriter.h \
     $$PWD/zxing-cpp/core/src/oned/ODMultiUPCEANReader.h \
-    $$PWD/zxing-cpp/core/src/oned/ODRSS14Reader.h \
-    $$PWD/zxing-cpp/core/src/oned/ODRSSExpandedReader.h \
     $$PWD/zxing-cpp/core/src/oned/ODReader.h \
     $$PWD/zxing-cpp/core/src/oned/ODRowReader.h \
-    $$PWD/zxing-cpp/core/src/oned/ODUPCAReader.h \
     $$PWD/zxing-cpp/core/src/oned/ODUPCAWriter.h \
     $$PWD/zxing-cpp/core/src/oned/ODUPCEANCommon.h \
-    $$PWD/zxing-cpp/core/src/oned/ODUPCEANExtensionSupport.h \
-    $$PWD/zxing-cpp/core/src/oned/ODUPCEANReader.h \
-    $$PWD/zxing-cpp/core/src/oned/ODUPCEReader.h \
     $$PWD/zxing-cpp/core/src/oned/ODUPCEWriter.h \
     $$PWD/zxing-cpp/core/src/oned/ODWriterHelper.h \
-    $$PWD/zxing-cpp/core/src/oned/rss/ODRSSDataCharacter.h \
     $$PWD/zxing-cpp/core/src/oned/rss/ODRSSExpandedBinaryDecoder.h \
-    $$PWD/zxing-cpp/core/src/oned/rss/ODRSSExpandedPair.h \
-    $$PWD/zxing-cpp/core/src/oned/rss/ODRSSExpandedRow.h \
     $$PWD/zxing-cpp/core/src/oned/rss/ODRSSFieldParser.h \
-    $$PWD/zxing-cpp/core/src/oned/rss/ODRSSFinderPattern.h \
     $$PWD/zxing-cpp/core/src/oned/rss/ODRSSGenericAppIdDecoder.h \
-    $$PWD/zxing-cpp/core/src/oned/rss/ODRSSPair.h \
-    $$PWD/zxing-cpp/core/src/oned/rss/ODRSSReaderHelper.h \
     $$PWD/zxing-cpp/core/src/pdf417/PDFBarcodeMetadata.h \
     $$PWD/zxing-cpp/core/src/pdf417/PDFBarcodeValue.h \
     $$PWD/zxing-cpp/core/src/pdf417/PDFBoundingBox.h \
@@ -152,8 +142,6 @@ HEADERS += \
     $$PWD/zxing-cpp/core/src/pdf417/PDFReader.h \
     $$PWD/zxing-cpp/core/src/pdf417/PDFScanningDecoder.h \
     $$PWD/zxing-cpp/core/src/pdf417/PDFWriter.h \
-    $$PWD/zxing-cpp/core/src/qrcode/QRAlignmentPattern.h \
-    $$PWD/zxing-cpp/core/src/qrcode/QRAlignmentPatternFinder.h \
     $$PWD/zxing-cpp/core/src/qrcode/QRBitMatrixParser.h \
     $$PWD/zxing-cpp/core/src/qrcode/QRCodecMode.h \
     $$PWD/zxing-cpp/core/src/qrcode/QRDataBlock.h \
@@ -165,9 +153,6 @@ HEADERS += \
     $$PWD/zxing-cpp/core/src/qrcode/QREncodeResult.h \
     $$PWD/zxing-cpp/core/src/qrcode/QREncoder.h \
     $$PWD/zxing-cpp/core/src/qrcode/QRErrorCorrectionLevel.h \
-    $$PWD/zxing-cpp/core/src/qrcode/QRFinderPattern.h \
-    $$PWD/zxing-cpp/core/src/qrcode/QRFinderPatternFinder.h \
-    $$PWD/zxing-cpp/core/src/qrcode/QRFinderPatternInfo.h \
     $$PWD/zxing-cpp/core/src/qrcode/QRFormatInformation.h \
     $$PWD/zxing-cpp/core/src/qrcode/QRMaskUtil.h \
     $$PWD/zxing-cpp/core/src/qrcode/QRMatrixUtil.h \
@@ -190,13 +175,16 @@ SOURCES += \
     $$PWD/SBarcodeFilter.cpp \
     $$PWD/SBarcodeGenerator.cpp \
     $$PWD/zxing-cpp/core/src/BarcodeFormat.cpp \
+    $$PWD/zxing-cpp/core/src/BinaryBitmap.cpp \
     $$PWD/zxing-cpp/core/src/BitArray.cpp \
     $$PWD/zxing-cpp/core/src/BitMatrix.cpp \
     $$PWD/zxing-cpp/core/src/BitMatrixIO.cpp \
     $$PWD/zxing-cpp/core/src/BitSource.cpp \
     $$PWD/zxing-cpp/core/src/CharacterSetECI.cpp \
+    $$PWD/zxing-cpp/core/src/ConcentricFinder.cpp \
     $$PWD/zxing-cpp/core/src/DecodeHints.cpp \
     $$PWD/zxing-cpp/core/src/DecodeStatus.cpp \
+    $$PWD/zxing-cpp/core/src/GTIN.cpp \
     $$PWD/zxing-cpp/core/src/GenericGF.cpp \
     $$PWD/zxing-cpp/core/src/GenericGFPoly.cpp \
     $$PWD/zxing-cpp/core/src/GenericLuminanceSource.cpp \
@@ -225,10 +213,9 @@ SOURCES += \
     $$PWD/zxing-cpp/core/src/aztec/AZReader.cpp \
     $$PWD/zxing-cpp/core/src/aztec/AZToken.cpp \
     $$PWD/zxing-cpp/core/src/aztec/AZWriter.cpp \
-    $$PWD/zxing-cpp/core/src/datamatrix/DMBitMatrixParser.cpp \
+    $$PWD/zxing-cpp/core/src/datamatrix/DMBitLayout.cpp \
     $$PWD/zxing-cpp/core/src/datamatrix/DMDataBlock.cpp \
     $$PWD/zxing-cpp/core/src/datamatrix/DMDecoder.cpp \
-    $$PWD/zxing-cpp/core/src/datamatrix/DMDefaultPlacement.cpp \
     $$PWD/zxing-cpp/core/src/datamatrix/DMDetector.cpp \
     $$PWD/zxing-cpp/core/src/datamatrix/DMECEncoder.cpp \
     $$PWD/zxing-cpp/core/src/datamatrix/DMHighLevelEncoder.cpp \
@@ -248,30 +235,23 @@ SOURCES += \
     $$PWD/zxing-cpp/core/src/oned/ODCode39Writer.cpp \
     $$PWD/zxing-cpp/core/src/oned/ODCode93Reader.cpp \
     $$PWD/zxing-cpp/core/src/oned/ODCode93Writer.cpp \
-    $$PWD/zxing-cpp/core/src/oned/ODEAN13Reader.cpp \
+    $$PWD/zxing-cpp/core/src/oned/ODDataBarCommon.cpp \
+    $$PWD/zxing-cpp/core/src/oned/ODDataBarExpandedReader.cpp \
+    $$PWD/zxing-cpp/core/src/oned/ODDataBarReader.cpp \
     $$PWD/zxing-cpp/core/src/oned/ODEAN13Writer.cpp \
-    $$PWD/zxing-cpp/core/src/oned/ODEAN8Reader.cpp \
     $$PWD/zxing-cpp/core/src/oned/ODEAN8Writer.cpp \
-    $$PWD/zxing-cpp/core/src/oned/ODEANManufacturerOrgSupport.cpp \
     $$PWD/zxing-cpp/core/src/oned/ODITFReader.cpp \
     $$PWD/zxing-cpp/core/src/oned/ODITFWriter.cpp \
     $$PWD/zxing-cpp/core/src/oned/ODMultiUPCEANReader.cpp \
-    $$PWD/zxing-cpp/core/src/oned/ODRSS14Reader.cpp \
-    $$PWD/zxing-cpp/core/src/oned/ODRSSExpandedReader.cpp \
     $$PWD/zxing-cpp/core/src/oned/ODReader.cpp \
     $$PWD/zxing-cpp/core/src/oned/ODRowReader.cpp \
-    $$PWD/zxing-cpp/core/src/oned/ODUPCAReader.cpp \
     $$PWD/zxing-cpp/core/src/oned/ODUPCAWriter.cpp \
     $$PWD/zxing-cpp/core/src/oned/ODUPCEANCommon.cpp \
-    $$PWD/zxing-cpp/core/src/oned/ODUPCEANExtensionSupport.cpp \
-    $$PWD/zxing-cpp/core/src/oned/ODUPCEANReader.cpp \
-    $$PWD/zxing-cpp/core/src/oned/ODUPCEReader.cpp \
     $$PWD/zxing-cpp/core/src/oned/ODUPCEWriter.cpp \
     $$PWD/zxing-cpp/core/src/oned/ODWriterHelper.cpp \
     $$PWD/zxing-cpp/core/src/oned/rss/ODRSSExpandedBinaryDecoder.cpp \
     $$PWD/zxing-cpp/core/src/oned/rss/ODRSSFieldParser.cpp \
     $$PWD/zxing-cpp/core/src/oned/rss/ODRSSGenericAppIdDecoder.cpp \
-    $$PWD/zxing-cpp/core/src/oned/rss/ODRSSReaderHelper.cpp \
     $$PWD/zxing-cpp/core/src/pdf417/PDFBarcodeValue.cpp \
     $$PWD/zxing-cpp/core/src/pdf417/PDFBoundingBox.cpp \
     $$PWD/zxing-cpp/core/src/pdf417/PDFCodewordDecoder.cpp \
@@ -286,18 +266,13 @@ SOURCES += \
     $$PWD/zxing-cpp/core/src/pdf417/PDFReader.cpp \
     $$PWD/zxing-cpp/core/src/pdf417/PDFScanningDecoder.cpp \
     $$PWD/zxing-cpp/core/src/pdf417/PDFWriter.cpp \
-    $$PWD/zxing-cpp/core/src/qrcode/QRAlignmentPattern.cpp \
-    $$PWD/zxing-cpp/core/src/qrcode/QRAlignmentPatternFinder.cpp \
     $$PWD/zxing-cpp/core/src/qrcode/QRBitMatrixParser.cpp \
     $$PWD/zxing-cpp/core/src/qrcode/QRCodecMode.cpp \
     $$PWD/zxing-cpp/core/src/qrcode/QRDataBlock.cpp \
-    $$PWD/zxing-cpp/core/src/qrcode/QRDataMask.cpp \
     $$PWD/zxing-cpp/core/src/qrcode/QRDecoder.cpp \
     $$PWD/zxing-cpp/core/src/qrcode/QRDetector.cpp \
     $$PWD/zxing-cpp/core/src/qrcode/QREncoder.cpp \
     $$PWD/zxing-cpp/core/src/qrcode/QRErrorCorrectionLevel.cpp \
-    $$PWD/zxing-cpp/core/src/qrcode/QRFinderPattern.cpp \
-    $$PWD/zxing-cpp/core/src/qrcode/QRFinderPatternFinder.cpp \
     $$PWD/zxing-cpp/core/src/qrcode/QRFormatInformation.cpp \
     $$PWD/zxing-cpp/core/src/qrcode/QRMaskUtil.cpp \
     $$PWD/zxing-cpp/core/src/qrcode/QRMatrixUtil.cpp \


### PR DESCRIPTION
Update SCodes.pri headers and sources to match latest zxing-cpp version (release 1.2.0).
https://github.com/nu-book/zxing-cpp/commit/2dad8be2466a2bd46037267d9f0e728e08b79140

Using Screen QML type requires importing QtQuick Window module in ScannerPage.qml
W libQmlBarcodeReader_armeabi-v7a.so: qrc:/qml/ScannerPage.qml:12: ReferenceError: Screen is not defined
W libQmlBarcodeReader_armeabi-v7a.so: qrc:/qml/ScannerPage.qml:10: ReferenceError: Screen is not defined