### PR TITLE
9 add support for more formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,33 @@ SCodes supports generating barcodes as well. It is covered in ["How to generate 
 
 ## Supported Formats
 
-ZXing-C++ Library supports many other formats, but currently it is possible to only use these two barcode formats.
+There are plenty of supported formats and we constantly work on adding new.
 
-|    1D    |    2D
-| -------- | -------
-| Code 128 | QR Code
+## Supported 1D Formats
+
+|      Format      |    Supports scanning     |    Supports generating
+| ---------------- | ------------------------ |    -------------------
+|      UPC-A       |   <center>❌</center>    |   <center>✔️</center>
+|      UPC-E       |   <center>❌</center>    |   <center>✔️</center>
+|      EAN-8       |   <center>❌</center>    |   <center>✔️</center>
+|      EAN-13      |   <center>❌</center>    |   <center>✔️</center>
+|     DataBar      |   <center>❌</center>    |   <center>❌</center>
+| DataBar Expanded |   <center>❌</center>    |   <center>❌</center>
+|     Code 39      |   <center>❌</center>    |   <center>✔️</center>
+|     Code 93      |   <center>❌</center>    |   <center>✔️</center>
+|     Code 128     |   <center>❌</center>    |   <center>✔️</center>
+|     Codabar      |   <center>✔️</center>    |   <center>✔️</center>
+|       ITF        |   <center>❌</center>    |   <center>✔️</center>
+
+## Supported 1D Formats
+
+|    Format    |    Supports scanning     |    Supports generating
+| ------------ | ------------------------ |    -------------------
+|   QR Code    |   <center>✔️</center>    |   <center>✔️</center>
+|  DataMatrix  |   <center>❌</center>    |   <center>✔️</center>
+|    Aztec     |   <center>❌</center>    |   <center>✔️</center>
+|    PDF417    |   <center>❌</center>    |   <center>✔️</center>
+|   MaxiCode   |   <center>❌</center>    |   <center>❌</center>
 
 
 # How to use wrapper?

--- a/README.md
+++ b/README.md
@@ -25,15 +25,15 @@ There are plenty of supported formats and we constantly work on adding new.
 
 |      Format      |    Supports scanning     |    Supports generating
 | ---------------- | ------------------------ |    -------------------
-|      UPC-A       |   <center>❌</center>    |   <center>✔️</center>
-|      UPC-E       |   <center>❌</center>    |   <center>✔️</center>
-|      EAN-8       |   <center>❌</center>    |   <center>✔️</center>
-|      EAN-13      |   <center>❌</center>    |   <center>✔️</center>
-|     DataBar      |   <center>❌</center>    |   <center>❌</center>
+|      UPC-A       |   <center>✔️</center>    |   <center>✔️</center>
+|      UPC-E       |   <center>✔️</center>    |   <center>✔️</center>
+|      EAN-8       |   <center>✔️</center>    |   <center>✔️</center>
+|      EAN-13      |   <center>✔️</center>    |   <center>✔️</center>
+|     DataBar      |   <center>✔️</center>    |   <center>❌</center>
 | DataBar Expanded |   <center>❌</center>    |   <center>❌</center>
-|     Code 39      |   <center>❌</center>    |   <center>✔️</center>
-|     Code 93      |   <center>❌</center>    |   <center>✔️</center>
-|     Code 128     |   <center>❌</center>    |   <center>✔️</center>
+|     Code 39      |   <center>✔️</center>    |   <center>✔️</center>
+|     Code 93      |   <center>✔️</center>    |   <center>✔️</center>
+|     Code 128     |   <center>✔️</center>    |   <center>✔️</center>
 |     Codabar      |   <center>✔️</center>    |   <center>✔️</center>
 |       ITF        |   <center>❌</center>    |   <center>✔️</center>
 
@@ -42,9 +42,9 @@ There are plenty of supported formats and we constantly work on adding new.
 |    Format    |    Supports scanning     |    Supports generating
 | ------------ | ------------------------ |    -------------------
 |   QR Code    |   <center>✔️</center>    |   <center>✔️</center>
-|  DataMatrix  |   <center>❌</center>    |   <center>✔️</center>
-|    Aztec     |   <center>❌</center>    |   <center>✔️</center>
-|    PDF417    |   <center>❌</center>    |   <center>✔️</center>
+|  DataMatrix  |   <center>✔️</center>    |   <center>✔️</center>
+|    Aztec     |   <center>✔️</center>    |   <center>✔️</center>
+|    PDF417    |   <center>✔️</center>    |   <center>✔️</center>
 |   MaxiCode   |   <center>❌</center>    |   <center>❌</center>
 
 
@@ -88,6 +88,18 @@ import com.scythestudio.scodes 1.0
 
 6. You are done. Get inspired by [QML Barcode Reader demo](https://github.com/scytheStudio/SCodes/blob/master/examples/QmlBarcodeReader/qml/ScannerPage.qml) to test wrapper.
 
+### Trying various formats
+`SBarcodeFilter` is a class that you need to use for scanning case. By default it scans only specific basic formats of code (Code 39, Code 93, Code 128, QR Code and DataMatrix.).
+The goal of that is to limit number of possible formats and improve performance.
+
+To specify formats that should be accepted by the `SBarcodeFilter` instance, you need to set it's `format` property accordingly. This property allows setting multiple enum values as it's for flags. Add the following to your `SBarcodeFilter` item in Qml code:
+```qml
+Component.onCompleted: {
+    barcodeFilter.format = SCodes.OneDCodes
+}
+```
+See the enumeration values that represent supported formats in [SBarcodeFormat.h](https://github.com/scytheStudio/SCodes/blob/master/src/SBarcodeFormat.h)
+To accept all supported formats use `SCodes.Any`.
 
 ## Note 
 

--- a/examples/QmlBarcodeGenerator/QmlBarcodeGenerator.pro
+++ b/examples/QmlBarcodeGenerator/QmlBarcodeGenerator.pro
@@ -1,6 +1,7 @@
 include("../../src/SCodes.pri")
 
 QT += quick
+CONFIG += c++17
 
 DEFINES += QT_DEPRECATED_WARNINGS
 
@@ -29,6 +30,4 @@ android {
 
     ANDROID_ABIS = armeabi-v7a
 }
-
-ANDROID_ABIS = armeabi-v7a
 

--- a/examples/QmlBarcodeGenerator/qml/GeneratorPage.qml
+++ b/examples/QmlBarcodeGenerator/qml/GeneratorPage.qml
@@ -12,9 +12,15 @@ ApplicationWindow {
 
   SBarcodeGenerator {
     id: barcodeGenerator
-    onProcessFinished: {
-      console.log(barcodeGenerator.filePath)
-      image.source = "file:///" + barcodeGenerator.filePath
+
+    onGenerationFinished: {
+      if (error == "") {
+        console.log(barcodeGenerator.filePath)
+        image.source = "file:///" + barcodeGenerator.filePath
+      } else {
+        generateLabel.text = error
+        generatePopup.open()
+      }
     }
   }
 
@@ -87,9 +93,11 @@ ApplicationWindow {
           text: qsTr("Generate")
           onClicked: {
             image.source = ""
-            if (!barcodeGenerator.process(textField.text)) {
+            if (textField.text === "") {
               generateLabel.text = "Input is empty"
               generatePopup.open()
+            } else {
+              barcodeGenerator.generate(textField.text)
             }
           }
         }
@@ -185,21 +193,62 @@ ApplicationWindow {
           model: ListModel {
             id: formats
 
-            ListElement {
-              text: "QR_CODE"
-            }
 
             ListElement {
-              text: "DATA_MATRIX"
+              text: "Aztec"
+            }
+            ListElement {
+              text: "Codabar"
+            }
+            ListElement {
+              text: "Code39"
+            }
+            ListElement {
+              text: "Code93"
+            }
+            ListElement {
+              text: "Code128"
+            }
+            ListElement {
+              text: "DataBar"
+            }
+            ListElement {
+              text: "DataBarExpanded"
+            }
+            ListElement {
+              text: "DataMatrix"
+            }
+            ListElement {
+              text: "EAN-8"
+            }
+            ListElement {
+              text: "EAN-13"
+            }
+            ListElement {
+              text: "ITF"
+            }
+            ListElement {
+              text: "MaxiCode"
+            }
+            ListElement {
+              text: "PDF417"
+            }
+            ListElement {
+              text: "QRCode"
+            }
+            ListElement {
+              text: "UPC-A"
+            }
+            ListElement {
+              text: "UPC-E"
             }
 
-            ListElement {
-              text: "CODE_128"
-            }
           }
           onCurrentIndexChanged: {
-            barcodeGenerator.barcodeFormatFromQMLString(formats.get(
-                                                          currentIndex).text)
+            var formatAsText = formats.get(currentIndex).text
+            // a separate method was used because of qml error
+            // when try to use it as overloaded setter
+            barcodeGenerator.setFormat(formatAsText)
           }
         }
 

--- a/examples/QmlBarcodeReader/QmlBarcodeReader.pro
+++ b/examples/QmlBarcodeReader/QmlBarcodeReader.pro
@@ -1,8 +1,13 @@
 include("../../src/SCodes.pri")
 
 QT += quick
+CONFIG += c++17
 
 DEFINES += QT_DEPRECATED_WARNINGS
+
+CONFIG += qmltypes
+QML_IMPORT_NAME = com.scythestudio.scodes
+QML_IMPORT_MAJOR_VERSION = 1
 
 SOURCES += \
     main.cpp

--- a/src/SBarcodeDecoder.cpp
+++ b/src/SBarcodeDecoder.cpp
@@ -116,15 +116,12 @@ bool SBarcodeDecoder::isDecoding() const
     return _isDecoding;
 }
 
-void SBarcodeDecoder::process(const QImage capturedImage)
+void SBarcodeDecoder::process(const QImage capturedImage, ZXing::BarcodeFormats formats)
 {
     setIsDecoding(true);
 
     const auto hints = DecodeHints()
-            .setFormats(BarcodeFormat::QR_CODE
-                        | BarcodeFormat::DATA_MATRIX
-                        | BarcodeFormat::CODE_128
-                        | BarcodeFormat::CODABAR)
+            .setFormats(formats)
             .setTryHarder(true)
             .setTryRotate(true)
             .setIsPure(false)

--- a/src/SBarcodeDecoder.h
+++ b/src/SBarcodeDecoder.h
@@ -4,6 +4,8 @@
 #include <QObject>
 #include <QVideoFrame>
 
+#include "SBarcodeFormat.h"
+
 class SBarcodeDecoder : public QObject
 {
     Q_OBJECT
@@ -20,7 +22,7 @@ public:
     static QImage imageFromVideoFrame(const QVideoFrame &videoFrame);
 
 public slots:
-    void process(const QImage capturedImage);
+    void process(const QImage capturedImage, ZXing::BarcodeFormats formats);
 
 signals:
     void isDecodingChanged(bool isDecoding);

--- a/src/SBarcodeFilter.h
+++ b/src/SBarcodeFilter.h
@@ -5,13 +5,15 @@
 #include <QtConcurrent/QtConcurrent>
 #include <qqml.h>
 
-#include "./SBarcodeDecoder.h"
+#include "SBarcodeDecoder.h"
+#include "SBarcodeFormat.h"
 
 class SBarcodeFilter : public QAbstractVideoFilter
 {
     Q_OBJECT
     Q_PROPERTY(QString captured READ captured NOTIFY capturedChanged)
     Q_PROPERTY(QRectF captureRect READ captureRect WRITE setCaptureRect NOTIFY captureRectChanged)
+    Q_PROPERTY(SCodes::SBarcodeFormats format READ format WRITE setFormat NOTIFY formatChanged)
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
         QML_ELEMENT
 #endif
@@ -29,9 +31,13 @@ public:
 
     QVideoFilterRunnable * createFilterRunnable() override;
 
+    const SCodes::SBarcodeFormats &format() const;
+    void setFormat(const SCodes::SBarcodeFormats &format);
+
 signals:
     void capturedChanged(const QString &captured);
     void captureRectChanged(const QRectF &captureRect);
+    void formatChanged(const SCodes::SBarcodeFormats &format);
 
 private slots:
     void setCaptured(const QString &captured);
@@ -43,6 +49,7 @@ private:
 
     SBarcodeDecoder *_decoder;
     QFuture<void> _imageFuture;
+    SCodes::SBarcodeFormats m_format = SCodes::SBarcodeFormat::Basic;
 };
 
 #endif // QRSCANNERFILTER_H

--- a/src/SBarcodeFormat.cpp
+++ b/src/SBarcodeFormat.cpp
@@ -51,3 +51,22 @@ SCodes::SBarcodeFormat SCodes::fromString(const QString &formatName)
 
     return SCodes::SBarcodeFormat::None;
 }
+
+ZXing::BarcodeFormats SCodes::toZXingFormat(SBarcodeFormats formats)
+{
+    ZXing::BarcodeFormats zXingformats;
+
+    int formatEnumIndex = SCodes::staticMetaObject.indexOfEnumerator("SBarcodeFormat");
+    QMetaEnum sBarcodeFormatEnumMeta = SCodes::staticMetaObject.enumerator(formatEnumIndex);
+
+    for (int i = 0; i < sBarcodeFormatEnumMeta.keyCount(); ++i) {
+        const auto key = sBarcodeFormatEnumMeta.key(i);
+        const auto value = sBarcodeFormatEnumMeta.keyToValue(key);
+        const auto enumValue = static_cast<SCodes::SBarcodeFormat>(value);
+        if (formats.testFlag(enumValue)) {
+            zXingformats |= toZXingFormat(enumValue);
+        }
+    }
+
+    return zXingformats;
+}

--- a/src/SBarcodeFormat.cpp
+++ b/src/SBarcodeFormat.cpp
@@ -1,0 +1,53 @@
+#include "SBarcodeFormat.h"
+
+namespace {
+const QMap<SCodes::SBarcodeFormat, ZXing::BarcodeFormat> k_formatsTranslations
+{
+    {SCodes::SBarcodeFormat::None, ZXing::BarcodeFormat::None},
+    {SCodes::SBarcodeFormat::Aztec, ZXing::BarcodeFormat::Aztec},
+    {SCodes::SBarcodeFormat::Codabar, ZXing::BarcodeFormat::Codabar},
+    {SCodes::SBarcodeFormat::Code39, ZXing::BarcodeFormat::Code39},
+    {SCodes::SBarcodeFormat::Code93, ZXing::BarcodeFormat::Code93},
+    {SCodes::SBarcodeFormat::Code128, ZXing::BarcodeFormat::Code128},
+    {SCodes::SBarcodeFormat::DataBar, ZXing::BarcodeFormat::DataBar},
+    {SCodes::SBarcodeFormat::DataBarExpanded, ZXing::BarcodeFormat::DataBarExpanded},
+    {SCodes::SBarcodeFormat::DataMatrix, ZXing::BarcodeFormat::DataMatrix},
+    {SCodes::SBarcodeFormat::EAN8, ZXing::BarcodeFormat::EAN8},
+    {SCodes::SBarcodeFormat::EAN13, ZXing::BarcodeFormat::EAN13},
+    {SCodes::SBarcodeFormat::ITF, ZXing::BarcodeFormat::ITF},
+    {SCodes::SBarcodeFormat::MaxiCode, ZXing::BarcodeFormat::MaxiCode},
+    {SCodes::SBarcodeFormat::PDF417, ZXing::BarcodeFormat::PDF417},
+    {SCodes::SBarcodeFormat::QRCode, ZXing::BarcodeFormat::QRCode},
+    {SCodes::SBarcodeFormat::UPCA, ZXing::BarcodeFormat::UPCA},
+    {SCodes::SBarcodeFormat::UPCE, ZXing::BarcodeFormat::UPCE},
+
+    {SCodes::SBarcodeFormat::OneDCodes, ZXing::BarcodeFormat::OneDCodes},
+    {SCodes::SBarcodeFormat::TwoDCodes, ZXing::BarcodeFormat::TwoDCodes},
+    {SCodes::SBarcodeFormat::Any, ZXing::BarcodeFormat::Any},
+};
+}
+
+ZXing::BarcodeFormat SCodes::toZXingFormat(SBarcodeFormat format)
+{
+    return k_formatsTranslations[format];
+}
+
+QString SCodes::toString(SBarcodeFormat format)
+{
+    return QString(ZXing::ToString(toZXingFormat(format)));
+}
+
+SCodes::SBarcodeFormat SCodes::fromString(const QString &formatName)
+{
+    const auto zxingFormat = ZXing::BarcodeFormatFromString(formatName.toStdString());
+
+    QMapIterator<SCodes::SBarcodeFormat, ZXing::BarcodeFormat> it(k_formatsTranslations);
+    while (it.hasNext()) {
+        it.next();
+        if (it.value() == zxingFormat) {
+            return it.key();
+        }
+    }
+
+    return SCodes::SBarcodeFormat::None;
+}

--- a/src/SBarcodeFormat.h
+++ b/src/SBarcodeFormat.h
@@ -1,0 +1,46 @@
+#ifndef SBARCODEFORMAT_H
+#define SBARCODEFORMAT_H
+
+#include <qqml.h>
+#include "BarcodeFormat.h"
+
+namespace SCodes {
+    Q_NAMESPACE
+    QML_ELEMENT
+
+    enum class SBarcodeFormat {
+        None            = 0,
+        Aztec           = (1 << 0),
+        Codabar         = (1 << 1),
+        Code39          = (1 << 2),
+        Code93          = (1 << 3),
+        Code128         = (1 << 4),
+        DataBar         = (1 << 5),
+        DataBarExpanded = (1 << 6),
+        DataMatrix      = (1 << 7),
+        EAN8            = (1 << 8),
+        EAN13           = (1 << 9),
+        ITF             = (1 << 10),
+        MaxiCode        = (1 << 11),
+        PDF417          = (1 << 12),
+        QRCode          = (1 << 13),
+        UPCA            = (1 << 14),
+        UPCE            = (1 << 15),
+
+        OneDCodes = Codabar | Code39 | Code93 | Code128 | EAN8 | EAN13 | ITF | DataBar | DataBarExpanded | UPCA | UPCE,
+        TwoDCodes = Aztec | DataMatrix | MaxiCode | PDF417 | QRCode,
+        Any       = OneDCodes | TwoDCodes,
+        Basic     = Code128 | QRCode,
+    };
+
+    Q_DECLARE_FLAGS(SBarcodeFormats, SBarcodeFormat)
+    Q_DECLARE_OPERATORS_FOR_FLAGS(SBarcodeFormats)
+    Q_FLAG_NS(SBarcodeFormats)
+
+    ZXing::BarcodeFormat toZXingFormat(SBarcodeFormat format);
+
+    QString toString(SBarcodeFormat format);
+    SBarcodeFormat fromString(const QString &formatName);
+}
+
+#endif // SBARCODEFORMAT_H

--- a/src/SBarcodeFormat.h
+++ b/src/SBarcodeFormat.h
@@ -8,7 +8,7 @@ namespace SCodes {
     Q_NAMESPACE
     QML_ELEMENT
 
-    enum class SBarcodeFormat {
+    enum class SBarcodeFormat : int {
         None            = 0,
         Aztec           = (1 << 0),
         Codabar         = (1 << 1),
@@ -30,7 +30,7 @@ namespace SCodes {
         OneDCodes = Codabar | Code39 | Code93 | Code128 | EAN8 | EAN13 | ITF | DataBar | DataBarExpanded | UPCA | UPCE,
         TwoDCodes = Aztec | DataMatrix | MaxiCode | PDF417 | QRCode,
         Any       = OneDCodes | TwoDCodes,
-        Basic     = Code128 | QRCode,
+        Basic     = Code39 | Code93 | Code128 | QRCode | DataMatrix,
     };
 
     Q_DECLARE_FLAGS(SBarcodeFormats, SBarcodeFormat)
@@ -38,6 +38,7 @@ namespace SCodes {
     Q_FLAG_NS(SBarcodeFormats)
 
     ZXing::BarcodeFormat toZXingFormat(SBarcodeFormat format);
+    ZXing::BarcodeFormats toZXingFormat(SBarcodeFormats formats);
 
     QString toString(SBarcodeFormat format);
     SBarcodeFormat fromString(const QString &formatName);

--- a/src/SBarcodeGenerator.cpp
+++ b/src/SBarcodeGenerator.cpp
@@ -1,41 +1,49 @@
+#include "SBarcodeGenerator.h"
 #include <QStandardPaths>
 #ifdef Q_OS_ANDROID
 #include <QtAndroid>
 #endif
-#include "SBarcodeGenerator.h"
 #include "MultiFormatWriter.h"
 #include "TextUtfEncoding.h"
 
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb_image_write.h"
 
-SBarcodeGenerator::SBarcodeGenerator()
+SBarcodeGenerator::SBarcodeGenerator(QQuickItem *parent)
+    : QQuickItem(parent)
 {
 
 }
 
-bool SBarcodeGenerator::process(const QString &inputString)
+bool SBarcodeGenerator::generate(const QString &inputString)
 {
-    if (inputString.isEmpty()){
-        return false;
-    }
-    else {
-    ZXing::MultiFormatWriter writer = ZXing::MultiFormatWriter(_format).setMargin(_margin).setEccLevel(_eccLevel);
-    _bitmap = ZXing::ToMatrix<uint8_t>(writer.encode(ZXing::TextUtfEncoding::FromUtf8(inputString.toStdString()), _width, _height));
+    try {
+        if (inputString.isEmpty()) {
+            return false;
+        } else {
+            ZXing::MultiFormatWriter writer = ZXing::MultiFormatWriter(SCodes::toZXingFormat(m_format)).setMargin(_margin).setEccLevel(_eccLevel);
 
-    _filePath = QDir::tempPath() + "/" + _fileName + "." + _extension;
+            _bitmap = ZXing::ToMatrix<uint8_t>(writer.encode(ZXing::TextUtfEncoding::FromUtf8(inputString.toStdString()), _width, _height));
 
-    if (_extension == "png") {
-        stbi_write_png(_filePath.toStdString().c_str(), _bitmap.width(), _bitmap.height(), 1, _bitmap.data(), 0);
-    }
-    else if (_extension == "jpg" || _extension == "jpeg") {
-        stbi_write_jpg(_filePath.toStdString().c_str(), _bitmap.width(), _bitmap.height(), 1, _bitmap.data(), 0);
+            _filePath = QDir::tempPath() + "/" + _fileName + "." + _extension;
+
+            if (_extension == "png") {
+                stbi_write_png(_filePath.toStdString().c_str(), _bitmap.width(), _bitmap.height(), 1, _bitmap.data(), 0);
+            } else if (_extension == "jpg" || _extension == "jpeg") {
+                stbi_write_jpg(_filePath.toStdString().c_str(), _bitmap.width(), _bitmap.height(), 1, _bitmap.data(), 0);
+            }
+
+            emit generationFinished();
+
+            return true;
+        }
+    } catch (const std::exception &e) {
+        emit generationFinished(e.what());
+    } catch (...) {
+        emit generationFinished("Unsupported exception thrown");
     }
 
-    emit processFinished();
-
-    return true;
-    }
+    return false;
 }
 
 
@@ -62,7 +70,31 @@ bool SBarcodeGenerator::saveImage()
     return true;
 }
 
-void SBarcodeGenerator::barcodeFormatFromQMLString(const QString &format)
+SCodes::SBarcodeFormat SBarcodeGenerator::format() const
 {
-    _format = ZXing::BarcodeFormatFromString(format.toStdString());
+    return m_format;
+}
+
+void SBarcodeGenerator::setFormat(SCodes::SBarcodeFormat format)
+{
+    if (m_format != format) {
+        switch (format) {
+        case SCodes::SBarcodeFormat::None:
+            qWarning() << "You need to set a specific format";
+            return;
+        case SCodes::SBarcodeFormat::Any:
+        case SCodes::SBarcodeFormat::OneDCodes:
+        case SCodes::SBarcodeFormat::TwoDCodes:
+            qWarning() << "Multiple formats can't be used to generate a barcode";
+            return;
+        default:
+            m_format = format;
+            emit formatChanged(m_format);
+        }
+    }
+}
+
+void SBarcodeGenerator::setFormat(const QString &formatName)
+{
+    setFormat(SCodes::fromString(formatName));
 }

--- a/src/SBarcodeGenerator.h
+++ b/src/SBarcodeGenerator.h
@@ -1,15 +1,16 @@
 #ifndef SBARCODEGENERATOR_H
 #define SBARCODEGENERATOR_H
 
+#include <QDir>
+#include <QImage>
+#include <qqml.h>
 #include <QQuickItem>
 #include <QObject>
-#include <QImage>
-#include <QDir>
-#include <qqml.h>
 
-#include "BarcodeFormat.h"
 #include "BitMatrix.h"
 #include "ByteMatrix.h"
+
+#include "SBarcodeFormat.h"
 
 class SBarcodeGenerator : public QQuickItem
 {
@@ -19,45 +20,49 @@ class SBarcodeGenerator : public QQuickItem
     Q_PROPERTY(int margin MEMBER _margin NOTIFY marginChanged)
     Q_PROPERTY(int eccLevel MEMBER _eccLevel NOTIFY eccLevelChanged)
     Q_PROPERTY(QString fileName MEMBER _fileName NOTIFY fileNameChanged)
-    Q_PROPERTY(ZXing::BarcodeFormat format MEMBER _format)
     Q_PROPERTY(QString extension MEMBER _extension)
     Q_PROPERTY(QString filePath MEMBER _filePath)
     Q_PROPERTY(QString inputText MEMBER _inputText)
+    Q_PROPERTY(SCodes::SBarcodeFormat format READ format WRITE setFormat NOTIFY formatChanged)
+
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
         QML_ELEMENT
 #endif
 
 public:
-    SBarcodeGenerator();
+    explicit SBarcodeGenerator(QQuickItem *parent = nullptr);
+    ~SBarcodeGenerator() override {};
+
+    SCodes::SBarcodeFormat format() const;
+    void setFormat(SCodes::SBarcodeFormat format);
 
 public slots:
-    bool process(const QString &inputString);
+    bool generate(const QString &inputString);
+    void setFormat(const QString &formatName);
     bool saveImage();
-    void barcodeFormatFromQMLString(const QString &format);
 
 signals:
-    void processFinished();
-
+    void generationFinished(const QString &error = "");
     void widthChanged(int width);
-
     void heightChanged(int height);
-
     void marginChanged(int margin);
-
     void eccLevelChanged(int eccLevel);
+    void fileNameChanged(const QString &fileName);
 
-    void fileNameChanged(QString fileName);
+    void formatChanged(SCodes::SBarcodeFormat format);
 
 private:
     int _width = 500;
     int _height = 500;
     int _margin = 10;
     int _eccLevel = -1;
-    ZXing::BarcodeFormat _format = ZXing::BarcodeFormat::QRCode;
+
     QString _extension = "png";
     QString _fileName = "code";
     QString _filePath = "";
     QString _inputText = "";
+    SCodes::SBarcodeFormat m_format = SCodes::SBarcodeFormat::Code128;
+
     ZXing::Matrix<uint8_t> _bitmap = ZXing::Matrix<uint8_t>();
 };
 

--- a/src/SCodes.pri
+++ b/src/SCodes.pri
@@ -16,6 +16,7 @@ INCLUDEPATH += \
 HEADERS += \
     $$PWD/SBarcodeDecoder.h \
     $$PWD/SBarcodeFilter.h \
+    $$PWD/SBarcodeFormat.h \
     $$PWD/SBarcodeGenerator.h \
     $$PWD/qvideoframeconversionhelper_p.h \
     $$PWD/zxing-cpp/core/src/BarcodeFormat.h \
@@ -173,6 +174,7 @@ HEADERS += \
 SOURCES += \
     $$PWD/SBarcodeDecoder.cpp \
     $$PWD/SBarcodeFilter.cpp \
+    $$PWD/SBarcodeFormat.cpp \
     $$PWD/SBarcodeGenerator.cpp \
     $$PWD/zxing-cpp/core/src/BarcodeFormat.cpp \
     $$PWD/zxing-cpp/core/src/BinaryBitmap.cpp \


### PR DESCRIPTION
In this PR I made several changes:
- I significantly increased the number of supported formats, by creating SCodes::SBarcodeFormats flags
- I exposed the possibility to set formats accepted by SBarcodeFilter
- I updated the README

Support for the following formats (compared to current master) was added and tested:

- Generating
    - UPC-A
    - UPC-E
    - EAN-8
    - EAN-13
    - Code 39
    - Code 93
    - Codabar
    - ITF
    - Aztec
    - PDF417
- Scanning 
    - UPC-A
    - UPC-E
    - EAN-8
    - EAN-13
    - DataBar
    - Code 39
    - Code 93
    - Aztec
    - PDF417
