### PR TITLE
Skip the check of the videoframe handle type before conversion to QImage

### DIFF
--- a/src/SBarcodeDecoder.cpp
+++ b/src/SBarcodeDecoder.cpp
@@ -220,32 +220,27 @@ QImage SBarcodeDecoder::videoFrameToImage(const QVideoFrame &videoFrame, const Q
     }
 
     #else
+    // The CPU / GPU buffer check is done internally, or so it seems
+    QImage image = videoFrame.toImage();
 
-    auto handleType = videoFrame.handleType();
-
-    if (handleType == QVideoFrame::NoHandle) {
-
-        QImage image = videoFrame.toImage();
-
-        if (image.isNull()) {
-            return QImage();
-        }
-
-        if (image.format() != QImage::Format_ARGB32) {
-            image = image.convertToFormat(QImage::Format_ARGB32);
-        }
-
-        // that's because qml videooutput has no mapNormalizedRectToItem method
-#ifdef Q_OS_ANDROID
-        return image.copy(m_resolutionHeight/4, m_resolutionWidth/4, m_resolutionHeight/2, m_resolutionWidth/2);
-#else
-        return image.copy(captureRect);
-#endif
+    if (image.isNull()) {
+        return QImage();
     }
 
-    #endif
+    if (image.format() != QImage::Format_ARGB32) {
+        image = image.convertToFormat(QImage::Format_ARGB32);
+    }
 
-    return QImage();
+    // that's because qml videooutput has no mapNormalizedRectToItem method
+#ifdef Q_OS_ANDROID
+    return image.copy(m_resolutionHeight/4, m_resolutionWidth/4, m_resolutionHeight/2, m_resolutionWidth/2);
+#else
+    return image.copy(captureRect);
+#endif // Q_OS_ANDROID
+
+
+#endif // QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+
 }
 
 void SBarcodeDecoder::setResolution(const int &w, const int &h)


### PR DESCRIPTION
Original code checks if the videoframe's handle type is `VideoFrame::NoHandle` (CPU addressable) before the conversion to QImage. The other case, if the videoframe resides in GPU is not handled and image is not decoded in that case.

After looking into the QVideoFrame source [(link)](https://github.com/qt/qtmultimedia/blob/dev/src/multimedia/video/qvideoframeconverter.cpp#L267) it turns out that this check is already done in `.toImage()` method and aproperiate conversion is done within. I wasn't able to test this myself but it seems that skipping of this explicit check should be enough to make conversion work for both cpu and gpu frames.




