### PR TITLE
Improve camera management in code

### DIFF
--- a/examples/QmlBarcodeReader/qml/Qt6ScannerPage.qml
+++ b/examples/QmlBarcodeReader/qml/Qt6ScannerPage.qml
@@ -3,23 +3,27 @@ import QtQuick.Controls
 import QtMultimedia
 import com.scythestudio.scodes 1.0
 
+
 /*!
   Barcode scanner main page. All QML elements managing from here.
   */
 ApplicationWindow {
   id: root
 
-  width: Qt.platform.os === "android" || Qt.platform.os === "ios" ? Screen.width : 1280
-  height: Qt.platform.os === "android" || Qt.platform.os === "ios" ? Screen.height : 720
+  width: Qt.platform.os === "android"
+         || Qt.platform.os === "ios" ? Screen.width : 1280
+  height: Qt.platform.os === "android"
+          || Qt.platform.os === "ios" ? Screen.height : 720
 
   visible: true
 
   SBarcodeScanner {
     id: barcodeScanner
 
-    videoSink: videoOutput.videoSink
+    forwardVideoSink: videoOutput.videoSink
 
-    captureRect: Qt.rect(root.width / 4, root.height / 4, root.width / 2, root.height / 2)
+    captureRect: Qt.rect(root.width / 4, root.height / 4, root.width / 2,
+                         root.height / 2)
 
     onCapturedChanged: function (captured) {
       scanResultText.text = captured
@@ -92,10 +96,12 @@ ApplicationWindow {
   }
 
   onHeightChanged: {
-    barcodeScanner.captureRect = Qt.rect(width / 4, height / 4, width / 2, height / 2)
+    barcodeScanner.captureRect = Qt.rect(width / 4, height / 4, width / 2,
+                                         height / 2)
   }
 
   onWidthChanged: {
-    barcodeScanner.captureRect = Qt.rect(width / 4, height / 4, width / 2, height / 2)
+    barcodeScanner.captureRect = Qt.rect(width / 4, height / 4, width / 2,
+                                         height / 2)
   }
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
 
 project(SCodes LANGUAGES CXX)
+option(SS_SCODES_DEBUG OFF)
+
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
@@ -30,15 +32,23 @@ else()
     list(FILTER SOURCE_CPP EXCLUDE REGEX "SBarcodeScanner.cpp")
 endif()
 
-add_library(${PROJECT_NAME} STATIC ${SOURCE_CPP})
 
+add_library(${PROJECT_NAME} STATIC ${SOURCE_CPP})
+target_sources(${PROJECT_NAME} PRIVATE private/debug.h)
 set_target_properties(${PROJECT_NAME} PROPERTIES
     QT_QML_MODULE_VERSION 1.0
     QT_QML_MODULE_URI com.scythestudio.scodes
+
 )
+if(SS_SCODES_DEBUG)
+    message("${PROJECT_NAME} debug messages enabled: ${SS_SCODES_DEBUG}")
+    target_compile_definitions(${PROJECT_NAME} PUBLIC SS_SCODES_DEBUG)
+endif()
+
 
 target_link_libraries(${PROJECT_NAME} PUBLIC ZXing Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Multimedia Qt${QT_VERSION_MAJOR}::Concurrent Qt${QT_VERSION_MAJOR}::Quick)
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(${PROJECT_NAME} PRIVATE  "${CMAKE_CURRENT_SOURCE_DIR}/private")
 
 if (ANDROID)
 

--- a/src/SBarcodeDecoder.cpp
+++ b/src/SBarcodeDecoder.cpp
@@ -101,9 +101,6 @@ std::ostream& operator << (std::ostream& os, const std::vector<ZXing::ResultPoin
     return os;
 }
 
-static int m_resolutionWidth = DEFAULT_RES_W;
-static int m_resolutionHeight = DEFAULT_RES_H;
-
 SBarcodeDecoder::SBarcodeDecoder(QObject *parent) : QObject(parent)
 { }
 
@@ -231,7 +228,7 @@ QImage SBarcodeDecoder::videoFrameToImage(const QVideoFrame &videoFrame, const Q
 
     // that's because qml videooutput has no mapNormalizedRectToItem method
 #ifdef Q_OS_ANDROID
-    return image.copy(m_resolutionHeight/4, m_resolutionWidth/4, m_resolutionHeight/2, m_resolutionWidth/2);
+    return image.copy(m_resolution.height()/4, m_resolution.width()/4, m_resolution.height()/2, m_resolution.width()/2);
 #else
     return image.copy(captureRect);
 #endif // Q_OS_ANDROID
@@ -241,8 +238,12 @@ QImage SBarcodeDecoder::videoFrameToImage(const QVideoFrame &videoFrame, const Q
 
 }
 
-void SBarcodeDecoder::setResolution(const int &w, const int &h)
+void SBarcodeDecoder::setResolution(int w, int h)
 {
-    m_resolutionWidth = w;
-    m_resolutionHeight = h;
-} // SBarcodeDecoder::videoFrameToImage
+    m_resolution = QSize{w,h};
+}
+
+void SBarcodeDecoder::setResolution(const QSize& newRes)
+{
+    m_resolution = newRes;
+}

--- a/src/SBarcodeDecoder.h
+++ b/src/SBarcodeDecoder.h
@@ -60,7 +60,8 @@ public:
      * \param w - width of the resolution
      * \param h - heigth of the resolution
      */
-    void setResolution(const int &w, const int &h);
+    void setResolution(const QSize&);
+    [[deprecated("Use QSize overload instead")]] void setResolution(int w, int h);
 
 public slots:
     /*!
@@ -94,6 +95,7 @@ private:
      * \brief Captured string from barcode
      */
     QString m_captured = "";
+    QSize m_resolution;
 
     /*!
      * \fn void setCaptured(const QString &captured)

--- a/src/private/debug.h
+++ b/src/private/debug.h
@@ -1,0 +1,14 @@
+/*!
+ * This file contains simple debug print definitions that allow for turning on/off debug print in the SCodes library by
+ * adding SS_CODE_DEBUG in compile definitions
+ */
+#ifndef DEBUG_H
+#define DEBUG_H
+#include <QDebug>
+#ifdef SS_SCODE_DEBUG
+#define sDebug QMessageLogger(QT_MESSAGELOG_FILE, QT_MESSAGELOG_LINE, QT_MESSAGELOG_FUNC).debug
+#else
+#define sDebug while (false) QMessageLogger().noDebug
+#endif
+
+#endif // DEBUG_H


### PR DESCRIPTION
Improve Camera management in Qt6:
  * Changed videoSink property to forwardVideoSink, to better communicate intent
  * Added SS_SCODES_DEBUG flag for controlling debug messages of the library
  * Changed type of m_resolution in SBarcodeDecoder
  * Removed initCam, stopCam functions, spread their functionality to setCamera, makeDefaultCamera, componentComplete functions in order to better divide responsibilities
  * Change name handleFrameCaptured to better communicate intent
  * Removed some not-so-useful comment-documentation. Replaced it with shorter more consice comments. Left obvious functons with no documentation.