### PR TITLE
Exceptions from ZXing are now reported by errorOccured signal

### DIFF
--- a/src/SBarcodeDecoder.cpp
+++ b/src/SBarcodeDecoder.cpp
@@ -10,7 +10,8 @@
 #include <iostream>
 
 #include <ReadBarcode.h>
-
+#include <exception>
+#include <QScopeGuard>
 
 /*!
  * \brief Provide a interface to access `ZXing::ReadBarcode` method
@@ -79,11 +80,11 @@ Result ReadBarcode(const QImage& img, const ReaderOptions& options = { })
 
               default: return ImageFormat::None;
           }
-      };
+    };
 
     auto exec = [&](const QImage& img){
           return Result(ZXing::ReadBarcode({ img.bits(), img.width(), img.height(), ImgFmtFromQImg(img) }, options));
-      };
+     };
 
     return ImgFmtFromQImg(img) == ImageFormat::None ? exec(img.convertToFormat(QImage::Format_RGBX8888)) : exec(img);
 }
@@ -143,6 +144,8 @@ bool SBarcodeDecoder::  isDecoding() const
 
 void SBarcodeDecoder::process(const QImage capturedImage, ZXing::BarcodeFormats formats)
 {
+    // This will set the "isDecoding" to false automatically
+    auto decodeGuard = qScopeGuard([=](){setIsDecoding(false);});
     setIsDecoding(true);
 
     const auto readerOptions = ReaderOptions()
@@ -152,13 +155,16 @@ void SBarcodeDecoder::process(const QImage capturedImage, ZXing::BarcodeFormats 
       .setIsPure(false)
       .setBinarizer(Binarizer::LocalAverage);
 
-    const auto result = ReadBarcode(capturedImage, readerOptions);
+    try{
+        const auto result = ReadBarcode(capturedImage, readerOptions);
 
-    if (result.isValid()) {
-        setCaptured(result.text());
+        if (result.isValid()) {
+            setCaptured(result.text());
+        }
     }
-
-    setIsDecoding(false);
+    catch(std::exception& e) {
+        emit errorOccured("ZXing exception: " + QString::fromLocal8Bit(e.what()));
+    }
 }
 
 QImage SBarcodeDecoder::videoFrameToImage(const QVideoFrame &videoFrame, const QRect &captureRect) const

--- a/src/SBarcodeDecoder.h
+++ b/src/SBarcodeDecoder.h
@@ -70,7 +70,7 @@ public slots:
      * \param const QImage capturedImage - captured image.
      * \param ZXing::BarcodeFormats formats - barcode formats.
      */
-    void process(const QImage capturedImage, ZXing::BarcodeFormats formats);
+    void process(const QImage capturedImage, ZXing::BarcodeFormats formats) ;
 
 signals:
     /*!
@@ -84,6 +84,8 @@ signals:
      * \param const QString &captured - captured barcode string.
      */
     void capturedChanged(const QString &captured);
+
+    void errorOccured(QString errorString);
 
 private:
     /*!

--- a/src/SBarcodeDecoder.h
+++ b/src/SBarcodeDecoder.h
@@ -85,7 +85,7 @@ signals:
      */
     void capturedChanged(const QString &captured);
 
-    void errorOccured(QString errorString);
+    void errorOccured(const QString& errorString);
 
 private:
     /*!

--- a/src/SBarcodeScanner.h
+++ b/src/SBarcodeScanner.h
@@ -91,7 +91,7 @@ signals:
     void captureRectChanged(const QRectF &captureRect);
     void capturedChanged(const QString &captured);
     void cameraAvailableChanged();
-    void errorOccured(QString errorString);
+    void errorOccured(const QString& errorString);
 protected:
     QCamera* makeDefaultCamera();
 private:

--- a/src/SBarcodeScanner.h
+++ b/src/SBarcodeScanner.h
@@ -30,8 +30,6 @@ class SBarcodeScanner : public QVideoSink, public QQmlParserStatus
     Q_PROPERTY(QVideoSink* forwardVideoSink MEMBER m_forwardVideoSink WRITE setForwardVideoSink NOTIFY forwardVideoSinkChanged)
     /// Set this to the subsection of the frame that's acutally supposed to be scanned for qr code. In Normalized coordinates (0.0-1.0)
     Q_PROPERTY(QRectF captureRect READ captureRect WRITE setCaptureRect NOTIFY captureRectChanged)
-    /// (Readonly) This string is set to the description of possible encountered error. Empty if no error.
-    Q_PROPERTY(QString errorDescription READ errorDescription NOTIFY errorDescriptionChanged)
     /// Set to true if camera property is set
     Q_PROPERTY(bool cameraAvailable READ cameraAvailable NOTIFY cameraAvailableChanged)
     /// Optional property if you want to set your own camera as an video input for scanning. Default video input is chosen by default.
@@ -56,7 +54,6 @@ public:
     void setCaptureRect(const QRectF &captureRect);
     QString captured() const;
     bool cameraAvailable() const;
-    QString errorDescription() const;
     void setCamera(QCamera *newCamera);
     void setForwardVideoSink(QVideoSink* sink);
 public slots:
@@ -94,7 +91,7 @@ signals:
     void captureRectChanged(const QRectF &captureRect);
     void capturedChanged(const QString &captured);
     void cameraAvailableChanged();
-    void errorDescriptionChanged();
+    void errorOccured(QString errorString);
 protected:
     QCamera* makeDefaultCamera();
 private:
@@ -116,7 +113,6 @@ private:
 
     bool m_processing = true;
     bool m_cameraAvailable = false;
-    QString m_errorDescription = "";
 
     /*!
      * \fn void setCaptured(const QString &captured)
@@ -133,13 +129,6 @@ private:
      * \param bool available - camera availability status
      */
     void setCameraAvailable(bool available);
-
-    /*!
-     * \fn void setErrorDescription(const QString &newErrorDescription)
-     * \brief Function setting error message that occured during initialization
-     * \param const QString &newErrorDescription - error message
-     */
-    void setErrorDescription(const QString &newErrorDescription);
 };
 
 /*!


### PR DESCRIPTION
* Wrapped ZXing call in a try-catch block
* Changed error reporting to errorOccured signal instead of property