### PR TITLE
47 resetting captured after clicking scan again button added

### DIFF
--- a/src/SBarcodeDecoder.cpp
+++ b/src/SBarcodeDecoder.cpp
@@ -118,12 +118,7 @@ QString SBarcodeDecoder::captured() const
 
 void SBarcodeDecoder::setCaptured(const QString &captured)
 {
-    if (m_captured == captured) {
-        return;
-    }
-
     m_captured = captured;
-
     emit capturedChanged(m_captured);
 }
 

--- a/src/SBarcodeScanner.cpp
+++ b/src/SBarcodeScanner.cpp
@@ -128,10 +128,6 @@ QCamera *SBarcodeScanner::makeDefaultCamera()
 
 void SBarcodeScanner::setCaptured(const QString& captured)
 {
-    if (m_captured == captured) {
-        return;
-    }
-
     m_captured = captured;
     emit capturedChanged(m_captured);
 }


### PR DESCRIPTION
[Issue 47](https://github.com/scytheStudio/SCodes/issues/47)

After Button Click "Scan again" scanner doesn't emit signal to show scanned QR code.

Fix: `captured` setter always sets to new value and emits the `capturedChanged` signal.