### PR TITLE
45 Scan indicator fixed

### DIFF
--- a/examples/QmlBarcodeReader/qml/Qt6ScannerOverlay.qml
+++ b/examples/QmlBarcodeReader/qml/Qt6ScannerOverlay.qml
@@ -164,6 +164,7 @@ Item {
           target: scanIndicator
           property: "y"
           duration: 2000
+          to: captureZoneCorners.height
         }
 
         PropertyAnimation {
@@ -172,6 +173,7 @@ Item {
           target: scanIndicator
           property: "y"
           duration: 2000
+          to: 0
         }
       }
     }
@@ -204,8 +206,6 @@ Item {
   }
 
   onCaptureRectChanged: {
-    toTopAnimation.to = 10
-    toBottomAnimation.to = scanCapsuleText.x
     scanIndicatorAnimation.start()
   }
 }


### PR DESCRIPTION
[Issue 45](https://github.com/scytheStudio/SCodes/issues/45)

Currently: The scan indicator only goes to `y: 10`.

Fix: Scan indicator goes to `captureZoneCorners.height` and goes back to `y: 0`