### PR TITLE
fix: SBarcodeDecoder.cpp comments

### DIFF
--- a/src/SBarcodeDecoder.cpp
+++ b/src/SBarcodeDecoder.cpp
@@ -15,7 +15,7 @@
 #include "private/debug.h"
 
 /*!
- * \brief Provide a interface to access `ZXing::ReadBarcode` method
+ * \brief Provide an interface to access `ZXing::ReadBarcode` method
  */
 namespace ZXing {
 namespace Qt {
@@ -56,7 +56,7 @@ public:
 /*!
  * \fn Result ReadBarcode(const QImage& img, const ReaderOptions& options = { })
  * \brief Interface for calling ZXing::ReadBarcode method to get result as a text.
- * \param const QImage& img - referance of the image to be processed
+ * \param const QImage& img - reference of the image to be processed
  * \param const ReaderOptions& options - barcode decode hints
  */
 Result ReadBarcode(const QImage& img, const ReaderOptions& options = { })


### PR DESCRIPTION
- a**n** interface
- refer**e**nce

see:
https://www.merriam-webster.com/dictionary/interface#examples
and
https://www.merriam-webster.com/thesaurus/referance